### PR TITLE
ENH: Patch for some tornado/ipykernel/py35 issue

### DIFF
--- a/ipykernel_launcher.py
+++ b/ipykernel_launcher.py
@@ -3,7 +3,8 @@
 This is separate from the ipykernel package so we can avoid doing imports until
 after removing the cwd from sys.path.
 """
-
+import asyncio
+from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 import sys
 
 if __name__ == '__main__':
@@ -13,4 +14,7 @@ if __name__ == '__main__':
         del sys.path[0]
 
     from ipykernel import kernelapp as app
+    # Quantopian Note: this is a py35/tornado/ipykernel patch.
+    # Pleas remove it if we update this one day
+    asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy())
     app.launch_new_instance()


### PR DESCRIPTION
ipykernel: Due to some incompatibility between ipykernel/zmq/tornado/py35, I needed to add asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy()) to https://github.com/ipython/ipykernel/blob/master/ipykernel_launcher.py before launching a new instance (see https://www.tornadoweb.org/en/stable/asyncio.html#tornado.platform.asyncio.AnyThreadEventLoopPolicy). This behavior changed in tornado 5 and I was unable to get this issue reproduced locally, so quickly forked to get this worked. I don't think this is the proper way to do this, but didn't want to spend more time for POC.
